### PR TITLE
Added hwm_breached to boolean state check, renamed stop-writes

### DIFF
--- a/aerospike_nagios.py
+++ b/aerospike_nagios.py
@@ -490,7 +490,7 @@ append_perf=False
 if "dc_state" in args.stat:
     if value != 'CLUSTER_UP':
         RETURN_VAL=STATE_CRITICAL
-elif args.stat in ["stop-writes","system_swapping"]:
+elif args.stat in ["stop_writes","system_swapping","hwm_breached"]:
     if value == 'true':
         RETURN_VAL=STATE_CRITICAL
 elif args.stat in ["cluster_integrity"]:


### PR DESCRIPTION
This fixes an issue I was having where hwm_breached and stop_writes were not being alerted on `true` conditions.