### PR TITLE
Changed metrics naming

### DIFF
--- a/examples/aerospike.cfg
+++ b/examples/aerospike.cfg
@@ -59,7 +59,8 @@ define service{
 	hostgroup_name		aerospike
 	servicegroups		Aerospike Service Group
 	service_description	Aerospike NS Test High Water Mark
-	# hwm-breached is a boolean check, so it does not have warn/crit levels, use 0/0
+	# hwm_breached is a boolean check, so it does not have warn/crit levels, use 0/0
+	check_command		check_aerospike_namespace!hwm_breached!test!0!0
 	use					generic-service
 }
 
@@ -67,7 +68,7 @@ define service{
 	hostgroup_name		aerospike
 	servicegroups		Aerospike Service Group
 	service_description	Aerospike NS Test Stop Writes
-	check_command		check_aerospike_namespace!stop-writes!test!0!0
+	check_command		check_aerospike_namespace!stop_writes!test!0!0
 	use					generic-service
 }
 

--- a/nrpe/examples/aerospike.cfg
+++ b/nrpe/examples/aerospike.cfg
@@ -1,18 +1,9 @@
 define service {
         use                             generic-service
         host_name                       hostname
-        service_description             FreePctDisk
-					#option1 is the stat, option2 is the warn level, option3 is the cirtical level
-        check_command                   check_nrpe!aerospike free-pct-disk 20 10
-	    contact_groups  	    		admin
-        }
-
-define service {
-        use                             generic-service
-        host_name                       hostname
         service_description             FreePctMemory
 					#option1 is the stat, option2 is the warn level, option3 is the cirtical level
-        check_command                   check_nrpe!aerospike free-pct-memory 20 10
+        check_command                   check_nrpe!aerospike system_free_mem_pct 20 10
 	    contact_groups			        admin
         }
 
@@ -21,7 +12,7 @@ define service {
         host_name                       hostname
         service_description             Namespace_AvailablePct
 					#option1 is the stat, option2 is the warn level, option3 is the cirtical level
-        check_command                   check_nrpe!aerospike_namespace available_pct Namespace 20 10
+        check_command                   check_nrpe!aerospike_namespace device_available_pct Namespace 20 10
 	    contact_groups		        	admin
         }
 
@@ -30,7 +21,7 @@ define service {
         host_name                       hostname
         service_description             Namespace_FreePctDisk
 					#option1 is the stat, option2 is the warn level, option3 is the cirtical level
-        check_command                   check_nrpe!aerospike_namespace free-pct-disk Namespace 20 10
+        check_command                   check_nrpe!aerospike_namespace device_free_pct Namespace 20 10
     	contact_groups		        	admin
         }
 
@@ -39,6 +30,6 @@ define service {
         host_name                       hostname
         service_description             Namespace_FreePctMemory
 					#option1 is the stat, option2 is the warn level, option3 is the cirtical level
-        check_command                   check_nrpe!aerospike_namespace free-pct-memory Namespace 20 10
+        check_command                   check_nrpe!aerospike_namespace memory_free_pct Namespace 20 10
 	    contact_groups			        admin
         }


### PR DESCRIPTION
Some metrics names have changed. Tried on `Aerospike Community Edition build 4.6.0.4`:

```
# ./check_aerospike.py -h localhost -s stop-writes -n test -w 0 -c 0
None
# ./check_aerospike.py -h localhost -s stop_writes -n test -w 0 -c 0
Aerospike Stats - stop_writes=false

# ./check_aerospike.py -h localhost -s hwm-breached -n test -w 0 -c 0
hwm-breached is not a known statistic.
# ./check_aerospike.py -h localhost -s hwm_breached -n test -w 0 -c 0
Aerospike Stats - hwm_breached=false
```